### PR TITLE
Treat Code Browser and Code Search as two distinct entities

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -38,7 +38,8 @@ jobs:
             bash .github/scripts/web_check_and_report.sh 'webcheck' 'https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.17/index.html' '(Auto-detected) Bioconductor Archive Down' 'disrupted' 'Archive'
             bash .github/scripts/web_check_and_report.sh 'webcheck' 'https://mghp.osn.xsede.org/bir190004-bucket01/ExperimentHub/BioImageDbs/v02/EM_id0005_Mouse_Kidney_2D_All_Mito_1024_4dTensor_dataset.gif' '(Auto-detected) Bioconductor ExperimentHub Resource Endpoint Down' 'disrupted' 'Archive'
             bash .github/scripts/web_check_and_report.sh 'webcheck' 'https://mghp.osn.xsede.org/bir190004-bucket01/AnnotationHub/goldenpath' '(Auto-detected) Bioconductor AnnotationHub Resource Endpoint Down' 'disrupted' 'Archive'
-            bash .github/scripts/web_check_and_report.sh 'webcheck' 'https://code.bioconductor.org' '(Auto-detected) Bioconductor Code Browser Down' 'disrupted' 'Bioconductor Code Browser'
+            bash .github/scripts/web_check_and_report.sh 'webcheck' 'https://code.bioconductor.org/browse/' '(Auto-detected) Bioconductor Code Browser Down' 'disrupted' 'Bioconductor Code Browser'
+            bash .github/scripts/web_check_and_report.sh 'webcheck' 'https://code.bioconductor.org/search/' '(Auto-detected) Bioconductor Code Search Down' 'disrupted' 'Bioconductor Code Search'
             bash .github/scripts/web_check_and_report.sh 'statscheck' 'https://bioconductor.org/packages/stats/bioc/' '(Auto-detected) Bioconductor Package Stats Failed Check' 'disrupted' 'Package Stats'
             
             git commit -m "Update website checks $(date '+%Y-%m-%d-%H-%M-%S')"

--- a/config.yml
+++ b/config.yml
@@ -176,9 +176,13 @@ params:
       category: Websites
       link: https://slack.bioconductor.org
     - name: Bioconductor Code Browser
-      description: https://code.bioconductor.org
+      description: https://code.bioconductor.org/browse/
       category: Websites
-      link: https://code.bioconductor.org
+      link: https://code.bioconductor.org/browse/
+    - name: Bioconductor Code Search
+      description: https://code.bioconductor.org/search/
+      category: Websites
+      link: https://code.bioconductor.org/search/
     - name: Archive
       description: Access to older releases
       category: Websites


### PR DESCRIPTION
I had a chat this morning with Mike Smith and he explained that:

- the code browser landing page: https://code.bioconductor.org/
- the code browser git interface: https://code.bioconductor.org/browse/
- the code search: https://code.bioconductor.org/search/

Are 3 separate entities.

It can happen that only 1 out of the 3 is down and the status page should reflect that. This is what is happening at the moment with the git interface returning 404 while the other components work fine.

This PR removes the landing page entirely because it's just a static page so not the most interesting or fragile component but I could add it back if you think it's good to have it here.